### PR TITLE
Changed way httpclient is being created

### DIFF
--- a/src/main/java/edu/ksu/lti/launch/service/OauthTokenRefreshService.java
+++ b/src/main/java/edu/ksu/lti/launch/service/OauthTokenRefreshService.java
@@ -6,8 +6,10 @@ import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.log4j.Logger;
@@ -31,25 +33,23 @@ public class OauthTokenRefreshService {
     @Autowired
     private String canvasDomain;
     @Autowired
-    private HttpClientBuilder clientBuilder;
-    @Autowired
     private CanvasResponseParser canvasResponseParser;
 
     public String getRefreshedOauthToken(String refreshToken) throws IOException {
         HttpPost canvasRequest = createRefreshCanvasRequest(refreshToken);
-        HttpResponse response = clientBuilder.build().execute(canvasRequest);
-
-        if (response.getStatusLine() == null
-                || response.getStatusLine().getStatusCode() == 401
-                || response.getStatusLine().getStatusCode() == 400) {
-            LOG.warn("Refresh failed. Redirect to oauth flow");
-            throw new OauthTokenRequiredException();
-        } else if (response.getStatusLine().getStatusCode() != 200) {
-            String tokenUri = canvasRequest.getURI().toString();
-            throw new IOException(tokenUri + " returned a status of " + response.getStatusLine().getStatusCode());
-        } else {
-            return canvasResponseParser.parseToken(response);
-
+        try (CloseableHttpClient httpClient = createHttpClient();
+             CloseableHttpResponse response = httpClient.execute(canvasRequest)) {
+            if (response.getStatusLine() == null
+                    || response.getStatusLine().getStatusCode() == 401
+                    || response.getStatusLine().getStatusCode() == 400) {
+                LOG.warn("Refresh failed. Redirect to oauth flow");
+                throw new OauthTokenRequiredException();
+            } else if (response.getStatusLine().getStatusCode() != 200) {
+                String tokenUri = canvasRequest.getURI().toString();
+                throw new IOException(tokenUri + " returned a status of " + response.getStatusLine().getStatusCode());
+            } else {
+                return canvasResponseParser.parseToken(response);
+            }
         }
     }
 
@@ -76,4 +76,9 @@ public class OauthTokenRefreshService {
             throw new RuntimeException("Invalid encoding for canvas when requesting refresh oauthToken", e);
         }
     }
+
+    protected CloseableHttpClient createHttpClient() {
+        return HttpClientBuilder.create().build();
+    }
+
 }

--- a/src/main/java/edu/ksu/lti/launch/spring/config/LtiLaunchBeans.java
+++ b/src/main/java/edu/ksu/lti/launch/spring/config/LtiLaunchBeans.java
@@ -13,10 +13,4 @@ public class LtiLaunchBeans {
         return new CanvasResponseParser();
     }
 
-
-    @Bean
-    @Scope("prototype")
-    public HttpClientBuilder httpClientBuilder() {
-        return HttpClientBuilder.create();
-    }
 }

--- a/src/test/java/edu/ksu/lti/launch/service/OauthTokenRefreshServiceUTest.java
+++ b/src/test/java/edu/ksu/lti/launch/service/OauthTokenRefreshServiceUTest.java
@@ -2,15 +2,14 @@ package edu.ksu.lti.launch.service;
 
 import edu.ksu.lti.launch.exception.OauthTokenRequiredException;
 import edu.ksu.lti.launch.util.CanvasResponseParser;
-import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicStatusLine;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,15 +17,14 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.powermock.reflect.Whitebox;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -43,13 +41,11 @@ public class OauthTokenRefreshServiceUTest {
     @Mock
     private OauthTokenService mockOauthTokenService;
     @Mock
-    private HttpClientBuilder mockHttpClientBuilder;
-    @Mock
     private CloseableHttpResponse mockHttpResponse;
     @Mock
     private CanvasResponseParser canvasResponseParser;
     @InjectMocks
-    private OauthTokenRefreshService oauthTokenRefreshService;
+    private OauthTokenRefreshServiceWithMockedHttpClient oauthTokenRefreshService;
     @Mock
     private CloseableHttpClient mockHttpClient;
 
@@ -60,8 +56,17 @@ public class OauthTokenRefreshServiceUTest {
 
     @Before
     public void setupMocks() throws Exception {
-        when(mockHttpClientBuilder.build()).thenReturn(mockHttpClient);
         when(mockHttpClient.execute(any())).thenReturn(mockHttpResponse);
+    }
+
+    @After
+    public void httpClientConnectionIsClosed() throws Exception {
+        verify(mockHttpClient, times(1)).close();
+    }
+
+    @After
+    public void httpResponseIsClosed() throws Exception {
+        verify(mockHttpResponse, times(1)).close();
     }
 
     @Test
@@ -151,4 +156,16 @@ public class OauthTokenRefreshServiceUTest {
     }
 
 
+}
+
+/*
+ * Http client should be created within the OauthTokenRefreshService but we need to not create a new one for testing
+ */
+class OauthTokenRefreshServiceWithMockedHttpClient extends OauthTokenRefreshService {
+    private CloseableHttpClient mockedHttpClient;
+
+    @Override
+    protected CloseableHttpClient createHttpClient() {
+        return mockedHttpClient;
+    }
 }

--- a/src/test/java/edu/ksu/lti/launch/test/SpringContextITest.java
+++ b/src/test/java/edu/ksu/lti/launch/test/SpringContextITest.java
@@ -40,10 +40,6 @@ public class SpringContextITest {
     private OauthTokenRefreshService oauthTokenRefreshService;
     @Autowired
     private OauthTokenService oauthTokenService;
-    @Autowired
-    private HttpClientBuilder httpClientBuilder;
-    @Autowired
-    private HttpClientBuilder httpClientBuilder2;
 
     @Test
     public void testSpringContext() {
@@ -53,11 +49,6 @@ public class SpringContextITest {
         assertNotNull("Expected ltiLaunchCanvas to be instantiated by Spring", ltiLaunch);
         assertNotNull("Expected oauthTokenRefreshService to be instantiated by Spring", oauthTokenRefreshService);
         assertNotNull("Expected oauthTokenService to be instantiated by Spring", oauthTokenService);
-    }
-
-    @Test
-    public void httpClientBeanIsThreadSafe() {
-        Assert.assertTrue("Two classes share the same instance of httpClientBuilder. Bean is probably declared as singleton.", httpClientBuilder != httpClientBuilder2);
     }
 
 }


### PR DESCRIPTION
Now creating an httpclient every time getRefreshedOauthToken() is
called. This may be a non-optimal solution because it is fairly
expensive to create (connection pools, connection managers, ssl
factories etc..) but traffic is low enough for our applications it
should be okay. Also made sure we are closing connections
