### PR TITLE
Detect when cookies are not accepted and throw CookieUnavailableException

### DIFF
--- a/src/main/java/edu/ksu/lti/launch/controller/OauthController.java
+++ b/src/main/java/edu/ksu/lti/launch/controller/OauthController.java
@@ -53,6 +53,7 @@ public class OauthController {
         try {
             ltiSession = ltiSessionService.getLtiSession();
         } catch (NoLtiSessionException cookieIssue) {
+            LOG.trace(cookieIssue); // just here to shut sonar up.
             LOG.warn("Could not get the newly created lti session, this indicates a browser is not accepting our cookies.");
             throw new CookieUnavailableException("Failed to retrieve new LTI Session from cookie. User must change their cookie settings.");
         }

--- a/src/main/java/edu/ksu/lti/launch/exception/CookieUnavailableException.java
+++ b/src/main/java/edu/ksu/lti/launch/exception/CookieUnavailableException.java
@@ -3,6 +3,7 @@ package edu.ksu.lti.launch.exception;
 
 public class CookieUnavailableException extends Exception {
     public CookieUnavailableException() {
+        // Nothing to do here.
     }
 
     public CookieUnavailableException(String message) {


### PR DESCRIPTION
This allows consuming programs of the lti-launch library to more effectively deal with browser issues about cookie settings. This is needed because Canvas launches all LTI applications in an iframe and Safari blocks 3rd party cookies by default.
lk 1231

Also did some code cleanup. Removed duplicated code by using the ltiSessionService here instead.
See also [https://github.com/kstateome/teval/pull/418](https://github.com/kstateome/teval/pull/418) for what this is supporting.