### PR TITLE
Upgrading Maven to 3.5.2 (require 3.1+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ LTI Launch is a project designed to assist in the development of Java based LTI 
 
 ### Technologies Used
 - Java 8
+- Maven (Compatible with 3.5.2, requires 3.1+)
 - Spring MVC 4.1.6
 - Spring Security OAuth
 - Google GSON

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,26 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>[3.1,)</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>2.5.1</version>
       </plugin>


### PR DESCRIPTION
Only requiring a minimum of 3.1 since this is open source, and we don't want to be a pain for others that are behind a bit on maven.