### PR TITLE
Bump spring-security-oauth from 2.0.17.RELEASE to 2.0.19.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
       <dependency>
         <groupId>org.springframework.security.oauth</groupId>
         <artifactId>spring-security-oauth</artifactId>
-        <version>2.0.17.RELEASE</version>
+        <version>2.0.19.RELEASE</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>


### PR DESCRIPTION
Reopening a dependabot PR that I merged but it broke things so I backed it out until we can investigate the problem better.

Bumps [spring-security-oauth](https://github.com/SpringSource/spring-security-oauth) from 2.0.17.RELEASE to 2.0.19.RELEASE.
- [Release notes](https://github.com/SpringSource/spring-security-oauth/releases)
- [Commits](https://github.com/SpringSource/spring-security-oauth/compare/2.0.17.RELEASE...2.0.19.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>