### PR TITLE
78X - Cookie to URL session tracking

### DIFF
--- a/src/main/java/edu/ksu/lti/launch/controller/LtiLaunchController.java
+++ b/src/main/java/edu/ksu/lti/launch/controller/LtiLaunchController.java
@@ -43,11 +43,12 @@ public abstract class LtiLaunchController {
         ltiSession.setLtiLaunchData(ltiData);
         ServletRequestAttributes sra = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
         HttpSession newSession = sra.getRequest().getSession();
+        String jsessionid = newSession.getId();
         newSession.setAttribute(LtiSession.class.getName(), ltiSession);
         instanceChecker.assertValidInstance(ltiSession);
         LOG.info("launching LTI integration '" + getApplicationName() + "' from " + ltiSession.getCanvasDomain() + " for course: " + canvasCourseId + " as user " + eID);
         LOG.debug("forwarding user to: " + getInitialViewPath());
-        return "forward:" + getInitialViewPath();
+        return "redirect:" + getInitialViewPath() + ";jsessionid=" + jsessionid;
     }
 
     /** return the initial path that the user should be sent

--- a/src/main/java/edu/ksu/lti/launch/spring/config/LtiLaunchSecurityConfig.java
+++ b/src/main/java/edu/ksu/lti/launch/spring/config/LtiLaunchSecurityConfig.java
@@ -23,7 +23,10 @@ import org.springframework.security.web.header.writers.frameoptions.StaticAllowF
 import org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
+import javax.servlet.ServletContext;
+import javax.servlet.SessionTrackingMode;
 import java.net.URI;
+import java.util.EnumSet;
 
 /**
  * This configuration class sets up Spring Security to authenticate LTI
@@ -49,6 +52,9 @@ public class LtiLaunchSecurityConfig extends WebMvcConfigurerAdapter {
 
         @Autowired
         private ConfigService configService;
+
+        @Autowired
+        private ServletContext servletContext;
 
         @Override
         public void configure(WebSecurity web) throws Exception {
@@ -79,6 +85,7 @@ public class LtiLaunchSecurityConfig extends WebMvcConfigurerAdapter {
                         "script-src 'self' 'unsafe-inline' https://ajax.googleapis.com; " +
                         "style-src 'self' 'unsafe-inline' https://*.instructure.com https://www.k-state.edu" ))
                 .addHeaderWriter(new StaticHeadersWriter("P3P", "CP=\"This is just to make IE happy with cookies in this iframe\""));
+            servletContext.setSessionTrackingModes(EnumSet.of(SessionTrackingMode.URL));
         }
 
         private ProtectedResourceProcessingFilter configureProcessingFilter() {


### PR DESCRIPTION
Change Session Tracking mode to URL so that session isn't maintained with cookies (3rd party cookie/iframe issue). Change launch forward to redirect so that the URL is encoded with sessionid.