### PR TITLE
Merge 113AE into master for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <description>Java framework for authenticating LTI launch requests from the Canvas LMS</description>
   <url>https://github.com/kstateome/lti-launch</url>
 
-   <licenses>
+  <licenses>
     <license>
       <name>GNU Lesser General Public License (LGPL), Version 3</name>
       <url>http://www.fsf.org/licensing/licenses/lgpl.txt</url>
@@ -54,6 +54,8 @@
   <properties>
     <log4j2.version>2.17.1</log4j2.version>
     <maven.surefire.version>2.22.2</maven.surefire.version>
+    <spring.version>5.3.14</spring.version>
+    <spring-security.version>5.8.14</spring-security.version>
     <!-- Skip integration tests by default. They are enabled by an integration test specific profile -->
     <skipITs>true</skipITs>
   </properties>
@@ -267,7 +269,17 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-        <version>4.1.6.RELEASE</version>
+        <version>${spring.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context</artifactId>
+        <version>${spring.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-aop</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security.oauth</groupId>
@@ -275,9 +287,24 @@
         <version>2.0.17.RELEASE</version>
       </dependency>
       <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-core</artifactId>
+        <version>${spring-security.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-web</artifactId>
+        <version>${spring-security.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-config</artifactId>
+        <version>${spring-security.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-webmvc</artifactId>
-        <version>4.1.6.RELEASE</version>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -312,7 +339,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-test</artifactId>
-        <version>4.1.6.RELEASE</version>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.powermock</groupId>

--- a/src/main/java/edu/ksu/lti/launch/spring/config/LtiLaunchSecurityConfig.java
+++ b/src/main/java/edu/ksu/lti/launch/spring/config/LtiLaunchSecurityConfig.java
@@ -4,8 +4,8 @@ import edu.ksu.lti.launch.oauth.LtiConsumerDetailsService;
 import edu.ksu.lti.launch.oauth.LtiOAuthAuthenticationHandler;
 import edu.ksu.lti.launch.service.ConfigService;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -69,11 +69,14 @@ public class LtiLaunchSecurityConfig extends WebMvcConfigurerAdapter {
             if (StringUtils.isBlank(canvasUrl)) {
                 throw new RuntimeException("Missing canvas_url config value");
             }
-            http.requestMatchers()
-                .antMatchers("/launch").and()
+            http.securityMatchers()
+                .requestMatchers("/launch").and()
                 .addFilterBefore(configureProcessingFilter(), UsernamePasswordAuthenticationFilter.class)
-                .authorizeRequests().anyRequest().authenticated().and().csrf().disable()
-                .headers().addHeaderWriter(new XFrameOptionsHeaderWriter(new StaticAllowFromStrategy(new URI(canvasUrl))))
+                .authorizeHttpRequests().anyRequest().authenticated().and().csrf().disable()
+                .headers()
+                .frameOptions()
+                .disable()
+                .addHeaderWriter(new XFrameOptionsHeaderWriter(new StaticAllowFromStrategy(new URI(canvasUrl))))
                 .addHeaderWriter(new StaticHeadersWriter("Content-Security-Policy",
                         "default-src 'self' https://s.ksucloud.net https://*.instructure.com; " +
                         "font-src 'self' https://s.ksucloud.net https://*.instructure.com; " +


### PR DESCRIPTION
Disabling default frameOptions in newer version of spring security before setting a writer for the spring options.
The default needs to be disabled in order to override the default deny behaviour for frameoptions in the newer version of spring security framework.